### PR TITLE
Allow GorillaBot to connect to not-Freenode.

### DIFF
--- a/gorillabot/configure.py
+++ b/gorillabot/configure.py
@@ -113,11 +113,12 @@ class Configurator(object):
             print('\n')
             name = ""
             while name == "":
-                name = input("Unique name for this configuration: ")
+                name = self.prompt("Unique name for this configuration: ")
                 if name in existing.keys():
                     print('The name "{0}" is not unique.'.format(name))
                     name = ""
             settings = {name: {}}
+            settings[name]["server"] = self.prompt("Server")
             settings[name]["nick"] = self.prompt("Nick", "GorillaBot")
             settings[name]["realname"] = self.prompt("Ident", "GorillaBot")
             settings[name]["ident"] = self.prompt("Realname", "GorillaBot")
@@ -126,6 +127,11 @@ class Configurator(object):
             settings[name]["password"] = self.prompt("Server password (optional)", hidden=True)
             settings[name]["youtube"] = self.prompt("YouTube API key (optional)", hidden=True)
             settings[name]["forecast"] = self.prompt("Forecast.io API key (optional)", hidden=True)
+            nickserv_auth_response = self.prompt("Authenticate with NickServ (y/n)")
+            if nickserv_auth_response == 'y':
+                settings[name]["nickserv_auth"] = True
+            else:
+                settings[name]["nickserv_auth"] = False
             settings[name]["chans"] = {}
             settings[name]["botops"] = {}
             for chan in chans:

--- a/gorillabot/run_tests.py
+++ b/gorillabot/run_tests.py
@@ -1,0 +1,6 @@
+from tests.bot_tests import TestBot
+from tests.configurator_tests import TestConfigurator
+import unittest
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gorillabot/tests/bot_tests.py
+++ b/gorillabot/tests/bot_tests.py
@@ -1,0 +1,140 @@
+import unittest
+from socket import socket
+import logging
+
+from bot import Bot
+
+
+class MockSocket(socket):
+    def __init__(self):
+        super(MockSocket, self).__init__()
+        self.address = ""
+        self.port = ""
+        self.messages = []
+
+    def connect(self, address):
+        self.address = address[0]
+        self.port = address[1]
+
+    def settimeout(self, timeout):
+        pass
+
+    def sendall(self, data, flags=None):
+        self.messages.append(data)
+
+    def get_messages(self):
+        return self.messages
+
+class MockLogger(logging._loggerClass):
+    def __init__(self):
+        super(MockLogger, self).__init__("Test")
+
+    def debug(self, msg, *args, **kwargs):
+        pass
+
+    def info(self, msg, *args, **kwargs):
+        pass
+
+    def error(self, msg, *args, **kwargs):
+        pass
+
+class TestBot(unittest.TestCase):
+
+    def testConnectToConfiguredServer(self):
+        class MockBot(Bot):
+            def initialize(self):
+                self.configuration_name = "test_config"
+                self.configuration = {"server": "localhost",
+                                      "password": None,
+                                      "nick": "test_bot",
+                                      "ident": "test_bot",
+                                      "realname": "test_bot",
+                                      "nickserv_auth": False,
+                                      "chans": []}
+                self.logger = MockLogger()
+
+            def _get_socket(self):
+                return MockSocket()
+
+            def update_configuration(self, updated_configuration):
+                pass
+
+        bot = MockBot()
+        bot.initialize()
+        bot.connect()
+        self.assertEqual(bot.socket.address, "localhost")
+
+    def testNickServConfiguration_NoAuth(self):
+        class MockBot(Bot):
+            def __init__(self):
+                super(MockBot, self).__init__()
+                self.sent_messages = []
+
+            def initialize(self):
+                self.configuration_name = "test_config"
+                self.configuration = {"server": "localhost",
+                                      "password": None,
+                                      "nick": "test_bot",
+                                      "ident": "test_bot",
+                                      "realname": "test_bot",
+                                      "nickserv_auth": False,
+                                      "chans": []}
+                self.logger = MockLogger()
+
+            def _get_socket(self):
+                return MockSocket()
+
+            def send(self, message, hide=False):
+                self.sent_messages.append(message)
+
+            def get_sent_messages(self):
+                return self.sent_messages
+
+            def update_configuration(self, updated_configuration):
+                pass
+
+        bot = MockBot()
+        bot.initialize()
+        bot.connect()
+        sent_messages = bot.get_sent_messages()
+        nickserv_messages = [x for x in sent_messages if x.startswith("PRIVMSG NickServ")]
+        self.assertLess(len(nickserv_messages), 1)
+
+    def test_NickServConfiguration_Auth(self):
+        class MockBot(Bot):
+            def __init__(self):
+                super(MockBot, self).__init__()
+                self.sent_messages = []
+
+            def initialize(self):
+                self.configuration_name = "test_config"
+                self.configuration = {"server": "localhost",
+                                      "password": None,
+                                      "nick": "test_bot",
+                                      "ident": "test_bot",
+                                      "realname": "test_bot",
+                                      "nickserv_auth": True,
+                                      "chans": []}
+                self.logger = MockLogger()
+
+            def _get_socket(self):
+                return MockSocket()
+
+            def send(self, message, hide=False):
+                self.sent_messages.append(message)
+
+            def get_sent_messages(self):
+                return self.sent_messages
+
+            def update_configuration(self, updated_configuration):
+                pass
+
+        bot = MockBot()
+        bot.initialize()
+        bot.connect()
+        sent_messages = bot.get_sent_messages()
+        nickserv_messages = [x for x in sent_messages if x.startswith("PRIVMSG NickServ")]
+        self.assertEqual(len(nickserv_messages), 1, "Did not send a message to nickserv")
+
+
+

--- a/gorillabot/tests/configurator_tests.py
+++ b/gorillabot/tests/configurator_tests.py
@@ -1,0 +1,53 @@
+import unittest
+from configure import Configurator
+import json
+
+
+class TestConfigurator(unittest.TestCase):
+
+    def testGetConfiguration(self):
+        class MockConfigurator(Configurator):
+
+
+            def __init__(self):
+                super(MockConfigurator, self).__init__()
+                self.config_name = "testConf"
+                self.mock_answers = {"Unique name for this configuration: ": self.config_name,
+                                     "Nick": "MockBot",
+                                     "Ident": "MockIdent",
+                                     "Realname": "Mock Real Name",
+                                     "Channel(s)": "#quanticle",
+                                     "Bot operator(s)": "quanticle",
+                                     "Server password (optional)": "",
+                                     "YouTube API key (optional)": "",
+                                     "Forecast.io API key (optional)": "",
+                                     "Server": "localhost",
+                                     "Authenticate with NickServ (y/n)": "n"}
+                self.config = {}
+                self.prompts = []
+
+            def prompt(self, field, default=None, hidden=False):
+                self.prompts.append(field)
+                if field in self.mock_answers.keys():
+                    return self.mock_answers[field]
+                else:
+                    raise AttributeError("Field not found: " + field)
+
+            def reset(self):
+                pass
+
+            def get_settings(self):
+                return {}
+
+            def save_config(self, new_settings):
+                self.config = new_settings
+
+            def verify(self, settings, name):
+                return True
+
+        mockConfigurator = MockConfigurator()
+        mockConfigurator.create_new()
+        self.assertTrue("Server" in mockConfigurator.prompts)
+        self.assertEqual(mockConfigurator.config[mockConfigurator.config_name]["server"], "localhost")
+        self.assertTrue("Authenticate with NickServ (y/n)" in mockConfigurator.prompts)
+        self.assertFalse(mockConfigurator.config[mockConfigurator.config_name]["nickserv_auth"])


### PR DESCRIPTION
This patch allows Gorillabot to connect to servers other than Freenode by
introducing a prompt for server name and port. I've also added a basic set of
unit tests to verify that the bot uses the specified server name and port to
connect.